### PR TITLE
Modify int128 types for Centos 6

### DIFF
--- a/src/Hash.h
+++ b/src/Hash.h
@@ -17,7 +17,10 @@
 #else
   #include <stdint.h>     /* defines uint32_t etc */
 
-  typedef unsigned __int128 uint128_t;
+  /* modify types for Centos 6 */
+  /* typedef unsigned __int128 uint128_t; */
+  typedef  __uint128_t uint128_t;
+  typedef __int128_t int128_t;
 
   #define U128_LO(v) (v >> 64)
   #define U128_HI(v) (v & 0xFFFFFFFFFFFFFFFF)


### PR DESCRIPTION
Per http://stackoverflow.com/questions/34588650/uint128-t-does-not-name-a-type , using __int128_t and __uint128_t instead of __int128 and unsigned __int128. This fixes the compilation problem on Centos 6.
